### PR TITLE
Game Difficulty Slider Now Affects Number of Guards That Spawn

### DIFF
--- a/src/logic/configuration/Constants.java
+++ b/src/logic/configuration/Constants.java
@@ -9,7 +9,7 @@ public class Constants {
     public static final int NUM_COINS               = 4;
     public static final int NUM_TUNNELS             = 4;
     public static final int CHARACTER_VELOCITY      = 550;
-    public static final double PRECISION = 1000000000.0;
+    public static final double PRECISION 			= 1000000000.0;
     public static final int STADIUM_BORDER          = 110;
     public static final int COIN_BOUNDS             = 150;
     public static final int STARTING_SPEED          = 7;
@@ -26,8 +26,8 @@ public class Constants {
     public static final int COOLDOWN_TIME     		= 3000;
     public static final int HEALTHBAR_H				= 28;
     public static final int HEALTHBAR_W				= 124;
-    public static final int COOLDOWNBAR_H				= 28;
-    public static final int COOLDOWNBAR_W				= 124;
+    public static final int COOLDOWNBAR_H			= 28;
+    public static final int COOLDOWNBAR_W			= 124;
     public static final double CHAR_MAX_HEALTH		= 100.0;
     public static final double GUARD_DAMAGE			= -1.0;
 }

--- a/src/logic/configuration/Globals.java
+++ b/src/logic/configuration/Globals.java
@@ -1,9 +1,31 @@
 package logic.configuration;
 
 public class Globals {
-
+	
     private Globals(){
     }
 
-    public static double SETTINGS_MULTIPLIER = 1.0;
+    public static int TUNNELS_MODIFIER = 0;
+    
+    public static void setTunnelsModifier(double val) {
+    	int difference = 0;
+    	
+    	if (val < 2.0) {
+    		difference = -2;
+    	}
+    	else if (val < 4.0) {
+    		difference = -1;
+    	}
+    	else if (val < 6.0) {
+    		difference = 0;
+    	}
+    	else if (val < 8.0) {
+    		difference = 1;
+    	}
+    	else {
+    		difference = 2;
+    	}
+    	
+    	TUNNELS_MODIFIER = difference;
+    }
 }

--- a/src/logic/controllers/GraphicsController.java
+++ b/src/logic/controllers/GraphicsController.java
@@ -74,7 +74,7 @@ public class GraphicsController {
     		gc.setFill(Color.RED);
     		gc.fillRect(96, 12, Constants.HEALTHBAR_W, Constants.HEALTHBAR_H);
     	
-    		gc.setFill(Color.GREEN);
+    		gc.setFill(Color.BLUE);
     		gc.fillRect(96, 12, (int)healthWidth, Constants.HEALTHBAR_H);
     	
     		//resets fill color
@@ -83,15 +83,16 @@ public class GraphicsController {
     
     public void drawCooldownBar(double cooldownTime) {
     		double cooldownWidth = (Constants.COOLDOWNBAR_W *(cooldownTime/(Constants.COOLDOWN_TIME/1000)));
+    		gc.fillText("Jump:", 232, 34);
     		
     		gc.setFill(Color.BLACK);
-    		gc.fillRect(Constants.SCREEN_WIDTH/2-Constants.COOLDOWNBAR_W/2, Constants.SCREEN_HEIGHT-50, Constants.COOLDOWNBAR_W + 4, Constants.COOLDOWNBAR_H + 4);
+    		gc.fillRect(298, 10, Constants.COOLDOWNBAR_W + 4, Constants.COOLDOWNBAR_H + 4);
     	
     		gc.setFill(Color.BLACK);
-    		gc.fillRect(Constants.SCREEN_WIDTH/2-Constants.COOLDOWNBAR_W/2+2, Constants.SCREEN_HEIGHT-48, Constants.COOLDOWNBAR_W, Constants.COOLDOWNBAR_H);
+    		gc.fillRect(300, 12, Constants.COOLDOWNBAR_W, Constants.COOLDOWNBAR_H);
     	
     		gc.setFill(Color.YELLOW);
-    		gc.fillRect(Constants.SCREEN_WIDTH/2-Constants.COOLDOWNBAR_W/2+2, Constants.SCREEN_HEIGHT-48, (int)cooldownWidth, Constants.COOLDOWNBAR_H);
+    		gc.fillRect(300, 12, (int)cooldownWidth, Constants.COOLDOWNBAR_H);
     	
     		//resets fill color
     		gc.setFill(Color.WHITE);

--- a/src/logic/controllers/WorldItemController.java
+++ b/src/logic/controllers/WorldItemController.java
@@ -109,7 +109,7 @@ public class WorldItemController {
             if (tunnel.getY() > Constants.SCREEN_HEIGHT) {
                 tunnel.resetPosition();
             } else {
-                if (tunnel.noGuard() && Math.random() < Constants.GUARD_SPAWN_RATE*Globals.SETTINGS_MULTIPLIER) {
+                if (tunnel.noGuard() && Math.random() < Constants.GUARD_SPAWN_RATE) {
                     //There should be a better way to do this
                     guards.add(tunnel.spawnGuard());
                 }

--- a/src/logic/models/Tunnel.java
+++ b/src/logic/models/Tunnel.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import logic.configuration.Constants;
+import logic.configuration.Globals;
 import logic.configuration.Paths;
 
 import java.util.ArrayList;
@@ -80,7 +81,7 @@ public class Tunnel extends WorldItem {
     public static List<Tunnel> createTunnels() {
         tunnelPositions = new ArrayList<>();
         List<Tunnel> tunnels = new ArrayList<>();
-        for (int i = 0; i < Constants.NUM_TUNNELS; i++) {
+        for (int i = 0; i < Constants.NUM_TUNNELS + Globals.TUNNELS_MODIFIER; i++) {
             Tunnel tunnel = new Tunnel();
             tunnels.add(tunnel);
         }

--- a/src/logic/views/SettingsView.java
+++ b/src/logic/views/SettingsView.java
@@ -30,11 +30,10 @@ import javafx.scene.text.Text;
 
 public class SettingsView extends StreakerView {
     
-    final Slider difficulty = new Slider (0.5, 2, 1);
+    final Slider difficulty = new Slider (0, 10, 5);
     final Label difficultyCaption = new Label("Difficulty Level:");
     final static Color textColor = Color.BLACK;
-    final Label difficultyValue = new Label(
-                                            Double.toString(difficulty.getValue()));
+    final Label difficultyValue = new Label("Medium");
     AnchorPane root = new AnchorPane();
     GridPane grid = new GridPane();
     
@@ -57,7 +56,25 @@ public class SettingsView extends StreakerView {
         difficulty.valueProperty().addListener(new ChangeListener<Number>() {
             public void changed(ObservableValue<? extends Number> ov,
                                 Number old_val, Number new_val) {
-                difficultyValue.setText(String.format("%.2f", new_val));
+            	String diffText = "Intermediate";
+            	double n = new_val.doubleValue();
+            	if (n < 2.0) {
+            		diffText = "Beginner";
+            	}
+            	else if (n < 4.0) {
+            		diffText = "Easy";
+            	}
+            	else if (n < 6.0) {
+            		diffText = "Medium";
+            	}
+            	else if (n < 8.0) {
+            		diffText = "Hard";
+            	}
+            	else {
+            		diffText = "Expert";
+            	}
+            	
+                difficultyValue.setText(diffText);
             }
         });
         
@@ -114,7 +131,7 @@ public class SettingsView extends StreakerView {
         a1.setFill(Color.RED);
         
         root.getChildren().add(a1);
-        Globals.SETTINGS_MULTIPLIER = difficulty.getValue();
+        Globals.setTunnelsModifier(difficulty.getValue());
     }
     
     


### PR DESCRIPTION
reworked game difficulty to affect number of tunnels present in game

previously, it affected how quickly a guard spawned at a tunnel after the tunnel's position was reset as a result of going out of the bottom bounds of the screen, but it now modifies the number of tunnels present (defaults at 4, now varies between 2 and 6, where one guard spawns from each tunnel each time it passes through the screen)

redid label corresponding to settings slider to reflect these changes

slider labels now display "beginner," "easy," "medium," "hard," and "expert"

Side Note: I also relocated the jump cooldown bar to be next to the health bar, and changed the health bar color to be blue to provide higher contrast from the turf background